### PR TITLE
Hide VirtualBox host-only adapters from indicator

### DIFF
--- a/src/common/Widgets/NMVisualizer.vala
+++ b/src/common/Widgets/NMVisualizer.vala
@@ -90,7 +90,8 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
     private void device_added_cb (NM.Device device) {
         if (device.get_iface ().has_prefix ("vmnet") ||
             device.get_iface ().has_prefix ("lo") ||
-            device.get_iface ().has_prefix ("veth")) {
+            device.get_iface ().has_prefix ("veth") ||
+            device.get_iface ().has_prefix ("vboxnet")) {
             return;
         }
 


### PR DESCRIPTION
When using VirtualBox virtual machines with host-only adapters configured, extra network interfaces are created on the host machine. These are picked up by the network indicator.

There's little point showing them there, so this branch proposes not adding them to the indicator.

![screenshot from 2017-09-15 16 30 30](https://user-images.githubusercontent.com/3372394/30491241-9a4e5186-9a34-11e7-904f-a96fb4280748.png)
