### PR TITLE
Update network state on addition/removal of network interfaces

### DIFF
--- a/src/common/Widgets/NMVisualizer.vala
+++ b/src/common/Widgets/NMVisualizer.vala
@@ -68,6 +68,7 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
         }
 
         update_interfaces_names ();
+        update_state ();
     }
 
     void update_interfaces_names () {

--- a/src/common/Widgets/NMVisualizer.vala
+++ b/src/common/Widgets/NMVisualizer.vala
@@ -134,6 +134,7 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
 
         update_interfaces_names ();
         update_all ();
+        update_state ();
         show_all ();
     }
 


### PR DESCRIPTION
Previously, when new network interfaces were added/removed, we weren't doing the check to determine whether we needed to select a new icon for the panel.

This sometimes resulted in a suboptimal icon being selected when wingpanel first loads and probably caused some issues when added and removing pluggable network devices.