### PR TITLE
Mobile/cellular broadband support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ vala_precompile (VALA_C ${CMAKE_PROJECT_NAME}
   Widgets/EtherInterface.vala
   Widgets/VpnInterface.vala
   Widgets/WifiInterface.vala
+  Widgets/ModemInterface.vala
   common/Utils.vala
   common/Widgets/WifiMenuItem.vala
   common/Widgets/VpnMenuItem.vala
@@ -30,6 +31,7 @@ vala_precompile (VALA_C ${CMAKE_PROJECT_NAME}
   common/Widgets/AbstractWifiInterface.vala
   common/Widgets/AbstractVpnInterface.vala
   common/Widgets/AbstractEtherInterface.vala
+  common/Widgets/AbstractModemInterface.vala
 
 PACKAGES
   wingpanel-2.0

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -19,8 +19,10 @@
 public class Network.Widgets.DisplayWidget : Gtk.Box {
     private Gtk.Image image;
 
-    uint animation_timeout;
-    int animation_state = 0;
+    uint wifi_animation_timeout;
+    int wifi_animation_state = 0;
+    uint cellular_animation_timeout;
+    int cellular_animation_state = 0;
 
     public DisplayWidget () {
         Object (orientation: Gtk.Orientation.HORIZONTAL);
@@ -35,9 +37,14 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
     }
 
     public void update_state (Network.State state, bool secure) {
-        if (animation_timeout > 0) {
-            Source.remove (animation_timeout);
-            animation_timeout = 0;
+        if (wifi_animation_timeout > 0) {
+            Source.remove (wifi_animation_timeout);
+            wifi_animation_timeout = 0;
+        }
+
+        if (cellular_animation_timeout > 0) {
+            Source.remove (cellular_animation_timeout);
+            cellular_animation_timeout = 0;
         }
 
         switch (state) {
@@ -66,10 +73,10 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
             image.icon_name = "network-wireless-signal-excellent-%ssymbolic".printf (secure? "secure-" : "");
             break;
         case Network.State.CONNECTING_WIFI:
-            animation_timeout = Timeout.add (300, () => {
-                animation_state = (animation_state + 1) % 4;
+            wifi_animation_timeout = Timeout.add (300, () => {
+                wifi_animation_state = (wifi_animation_state + 1) % 4;
                 string strength = "";
-                switch (animation_state) {
+                switch (wifi_animation_state) {
                 case 0:
                     strength = "weak";
                     break;
@@ -88,22 +95,22 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
             });
             break;
         case Network.State.CONNECTED_MOBILE_WEAK:
-            image.icon_name = "network-cellular-signal-weak-%ssymbolic".printf (secure? "secure-" : "");
+            image.icon_name = "network-cellular-signal-weak-%ssymbolic".printf (secure ? "secure-" : "");
             break;
         case Network.State.CONNECTED_MOBILE_OK:
-            image.icon_name = "network-cellular-signal-ok-%ssymbolic".printf (secure? "secure-" : "");
+            image.icon_name = "network-cellular-signal-ok-%ssymbolic".printf (secure ? "secure-" : "");
             break;
         case Network.State.CONNECTED_MOBILE_GOOD:
-            image.icon_name = "network-cellular-signal-good-%ssymbolic".printf (secure? "secure-" : "");
+            image.icon_name = "network-cellular-signal-good-%ssymbolic".printf (secure ? "secure-" : "");
             break;
         case Network.State.CONNECTED_MOBILE_EXCELLENT:
-            image.icon_name = "network-cellular-signal-excellent-%ssymbolic".printf (secure? "secure-" : "");
+            image.icon_name = "network-cellular-signal-excellent-%ssymbolic".printf (secure ? "secure-" : "");
             break;
         case Network.State.CONNECTING_MOBILE:
-            animation_timeout = Timeout.add (300, () => {
-                animation_state = (animation_state + 1) % 4;
+            cellular_animation_timeout = Timeout.add (300, () => {
+                cellular_animation_state = (cellular_animation_state + 1) % 4;
                 string strength = "";
-                switch (animation_state) {
+                switch (cellular_animation_state) {
                 case 0:
                     strength = "weak";
                     break;
@@ -117,7 +124,8 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
                     strength = "excellent";
                     break;
                 }
-                image.icon_name = "network-cellular-signal-" + strength + (secure? "secure-" : "")  + "-symbolic";
+
+                image.icon_name = "network-cellular-signal-" + strength + (secure ? "secure-" : "")  + "-symbolic";
                 return true;
             });
             break;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -87,20 +87,17 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
                 return true;
             });
             break;
-        case Network.State.CONNECTED_MOBILE:
-            image.icon_name = "network-cellular-connected-symbolic";
-            break;
         case Network.State.CONNECTED_MOBILE_WEAK:
-            image.icon_name = "network-cellular-signal-weak-symbolic";
+            image.icon_name = "network-cellular-signal-weak-%ssymbolic".printf (secure? "secure-" : "");
             break;
         case Network.State.CONNECTED_MOBILE_OK:
-            image.icon_name = "network-cellular-signal-ok-symbolic";
+            image.icon_name = "network-cellular-signal-ok-%ssymbolic".printf (secure? "secure-" : "");
             break;
         case Network.State.CONNECTED_MOBILE_GOOD:
-            image.icon_name = "network-cellular-signal-good-symbolic";
+            image.icon_name = "network-cellular-signal-good-%ssymbolic".printf (secure? "secure-" : "");
             break;
         case Network.State.CONNECTED_MOBILE_EXCELLENT:
-            image.icon_name = "network-cellular-signal-excellent-symbolic";
+            image.icon_name = "network-cellular-signal-excellent-%ssymbolic".printf (secure? "secure-" : "");
             break;
         case Network.State.CONNECTING_MOBILE:
             animation_timeout = Timeout.add (300, () => {
@@ -120,7 +117,7 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
                     strength = "excellent";
                     break;
                 }
-                image.icon_name = "network-cellular-signal-" + strength  + "-symbolic";
+                image.icon_name = "network-cellular-signal-" + strength + (secure? "secure-" : "")  + "-symbolic";
                 return true;
             });
             break;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -87,6 +87,46 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
                 return true;
             });
             break;
+        case Network.State.CONNECTED_MOBILE:
+            image.icon_name = "network-cellular-connected-symbolic";
+            break;
+        case Network.State.CONNECTED_MOBILE_WEAK:
+            image.icon_name = "network-cellular-signal-weak-symbolic";
+            break;
+        case Network.State.CONNECTED_MOBILE_OK:
+            image.icon_name = "network-cellular-signal-ok-symbolic";
+            break;
+        case Network.State.CONNECTED_MOBILE_GOOD:
+            image.icon_name = "network-cellular-signal-good-symbolic";
+            break;
+        case Network.State.CONNECTED_MOBILE_EXCELLENT:
+            image.icon_name = "network-cellular-signal-excellent-symbolic";
+            break;
+        case Network.State.CONNECTING_MOBILE:
+            animation_timeout = Timeout.add (300, () => {
+                animation_state = (animation_state + 1) % 4;
+                string strength = "";
+                switch (animation_state) {
+                case 0:
+                    strength = "weak";
+                    break;
+                case 1:
+                    strength = "ok";
+                    break;
+                case 2:
+                    strength = "good";
+                    break;
+                case 3:
+                    strength = "excellent";
+                    break;
+                }
+                image.icon_name = "network-cellular-signal-" + strength  + "-symbolic";
+                return true;
+            });
+            break;
+        case Network.State.FAILED_MOBILE:
+            image.icon_name = "network-cellular-offline-symbolic";
+            break;
         case Network.State.DISCONNECTED:
             image.icon_name = "network-wireless-offline-symbolic";
             break;

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -48,7 +48,7 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
             if (modem_item.get_active ()) {
                 nm_client.activate_connection (null, device, null, null);
             } else {
-                device.disconnect (() => { debug("Successfully disconnected."); });
+                device.disconnect (() => { debug ("Successfully disconnected."); });
             }
         });
 

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -32,7 +32,7 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
         modem_item.get_style_context ().add_class ("h4");
         modem_item.switched.connect (() => {
             if (modem_item.get_active ()) {
-                device.set_autoconnect (true);
+                nm_client.activate_connection (null, device, null, null);
             } else {
                 device.disconnect (() => { debug("Successfully disconnected."); });
             }
@@ -45,38 +45,38 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
 
     public override void update () {
         switch (device.state) {
-		    /* physically not connected */
-		    case NM.DeviceState.UNKNOWN:
-		    case NM.DeviceState.UNMANAGED:
-		    case NM.DeviceState.UNAVAILABLE:
-		    case NM.DeviceState.FAILED:
+            /* physically not connected */
+            case NM.DeviceState.UNKNOWN:
+            case NM.DeviceState.UNMANAGED:
+            case NM.DeviceState.UNAVAILABLE:
+            case NM.DeviceState.FAILED:
                 modem_item.sensitive = false;
                 modem_item.set_active (false);
                 state = State.FAILED_MOBILE;
                 break;    
-		    case NM.DeviceState.DISCONNECTED:            
-		    case NM.DeviceState.DEACTIVATING:
+            case NM.DeviceState.DISCONNECTED:
+            case NM.DeviceState.DEACTIVATING:
+                modem_item.sensitive = true;
+                modem_item.set_active (false);
+                state = State.FAILED_MOBILE;
+                break;
+            /* configuration */
+            case NM.DeviceState.PREPARE:
+            case NM.DeviceState.CONFIG:
+            case NM.DeviceState.NEED_AUTH:
+            case NM.DeviceState.IP_CONFIG:
+            case NM.DeviceState.IP_CHECK:
+            case NM.DeviceState.SECONDARIES:
                 modem_item.sensitive = true;
                 modem_item.set_active (true);
-			    state = State.FAILED_MOBILE;
-			    break;
-		    /* configuration */
-		    case NM.DeviceState.PREPARE:
-		    case NM.DeviceState.CONFIG:
-		    case NM.DeviceState.NEED_AUTH:
-		    case NM.DeviceState.IP_CONFIG:
-		    case NM.DeviceState.IP_CHECK:
-		    case NM.DeviceState.SECONDARIES:
+                state = State.CONNECTING_MOBILE;
+                break;
+            /* working */
+            case NM.DeviceState.ACTIVATED:
                 modem_item.sensitive = true;
                 modem_item.set_active (true);
-			    state = State.CONNECTING_MOBILE;
-			    break;
-		    /* working */
-		    case NM.DeviceState.ACTIVATED:
-                modem_item.sensitive = true;
-                modem_item.set_active (true);
-			    state = State.CONNECTED_MOBILE;
-			    break;
-		}
+                state = State.CONNECTED_MOBILE;
+                break;
+        }
     }
 }

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -1,0 +1,82 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
+
+public class Network.ModemInterface : Network.AbstractModemInterface {
+    private Wingpanel.Widgets.Switch modem_item;
+
+    public ModemInterface (NM.Client nm_client, NM.RemoteSettings nm_settings, NM.Device? _device) {
+        device = _device;
+        modem_item = new Wingpanel.Widgets.Switch (display_title);
+
+        notify["display-title"].connect (() => {
+            modem_item.set_caption (display_title);
+        });
+
+        modem_item.get_style_context ().add_class ("h4");
+        modem_item.switched.connect (() => {
+            if (modem_item.get_active ()) {
+                device.set_autoconnect (true);
+            } else {
+                device.disconnect (() => { debug("Successfully disconnected."); });
+            }
+        });
+
+        add (modem_item);
+
+        device.state_changed.connect (() => { update (); });
+    }
+
+    public override void update () {
+        switch (device.state) {
+		    /* physically not connected */
+		    case NM.DeviceState.UNKNOWN:
+		    case NM.DeviceState.UNMANAGED:
+		    case NM.DeviceState.UNAVAILABLE:
+		    case NM.DeviceState.FAILED:
+                modem_item.sensitive = false;
+                modem_item.set_active (false);
+                state = State.FAILED_MOBILE;
+                break;    
+		    case NM.DeviceState.DISCONNECTED:            
+		    case NM.DeviceState.DEACTIVATING:
+                modem_item.sensitive = true;
+                modem_item.set_active (true);
+			    state = State.FAILED_MOBILE;
+			    break;
+		    /* configuration */
+		    case NM.DeviceState.PREPARE:
+		    case NM.DeviceState.CONFIG:
+		    case NM.DeviceState.NEED_AUTH:
+		    case NM.DeviceState.IP_CONFIG:
+		    case NM.DeviceState.IP_CHECK:
+		    case NM.DeviceState.SECONDARIES:
+                modem_item.sensitive = true;
+                modem_item.set_active (true);
+			    state = State.CONNECTING_MOBILE;
+			    break;
+		    /* working */
+		    case NM.DeviceState.ACTIVATED:
+                modem_item.sensitive = true;
+                modem_item.set_active (true);
+			    state = State.CONNECTED_MOBILE;
+			    break;
+		}
+    }
+}

--- a/src/common/Utils.vala
+++ b/src/common/Utils.vala
@@ -28,7 +28,6 @@ public enum Network.State {
     CONNECTED_WIFI_OK,
     CONNECTED_WIFI_GOOD,
     CONNECTED_WIFI_EXCELLENT,
-    CONNECTED_MOBILE,
     CONNECTED_MOBILE_WEAK,
     CONNECTED_MOBILE_OK,
     CONNECTED_MOBILE_GOOD,
@@ -58,7 +57,6 @@ public enum Network.State {
             case Network.State.CONNECTED_WIFI_GOOD:
             case Network.State.CONNECTED_WIFI_EXCELLENT:
                 return 4;
-            case Network.State.CONNECTED_MOBILE:
             case Network.State.CONNECTED_MOBILE_WEAK:
             case Network.State.CONNECTED_MOBILE_OK:
             case Network.State.CONNECTED_MOBILE_GOOD:
@@ -90,7 +88,6 @@ namespace Network.Common.Utils {
         case Network.State.CONNECTED_WIFI_EXCELLENT:
         case Network.State.CONNECTED_WIRED:
         case Network.State.CONNECTED_VPN:
-        case Network.State.CONNECTED_MOBILE:
         case Network.State.CONNECTED_MOBILE_WEAK:
         case Network.State.CONNECTED_MOBILE_OK:
         case Network.State.CONNECTED_MOBILE_GOOD:

--- a/src/common/Utils.vala
+++ b/src/common/Utils.vala
@@ -28,11 +28,18 @@ public enum Network.State {
     CONNECTED_WIFI_OK,
     CONNECTED_WIFI_GOOD,
     CONNECTED_WIFI_EXCELLENT,
+    CONNECTED_MOBILE,
+    CONNECTED_MOBILE_WEAK,
+    CONNECTED_MOBILE_OK,
+    CONNECTED_MOBILE_GOOD,
+    CONNECTED_MOBILE_EXCELLENT,
     CONNECTING_WIFI,
+    CONNECTING_MOBILE,
     CONNECTING_WIRED,
     CONNECTING_VPN,
     FAILED_WIRED,
     FAILED_WIFI,
+    FAILED_MOBILE,
     FAILED_VPN;
 
     public int get_priority () {
@@ -41,23 +48,32 @@ public enum Network.State {
                 return 0;
             case Network.State.CONNECTING_WIFI:
                 return 1;
-            case Network.State.CONNECTED_WIRED:
+            case Network.State.CONNECTING_MOBILE:
                 return 2;
+            case Network.State.CONNECTED_WIRED:
+                return 3;
             case Network.State.CONNECTED_WIFI:
             case Network.State.CONNECTED_WIFI_WEAK:
             case Network.State.CONNECTED_WIFI_OK:
             case Network.State.CONNECTED_WIFI_GOOD:
             case Network.State.CONNECTED_WIFI_EXCELLENT:
-                return 3;
+                return 4;
+            case Network.State.CONNECTED_MOBILE:
+            case Network.State.CONNECTED_MOBILE_WEAK:
+            case Network.State.CONNECTED_MOBILE_OK:
+            case Network.State.CONNECTED_MOBILE_GOOD:
+            case Network.State.CONNECTED_MOBILE_EXCELLENT:
+                return 5;
             case Network.State.FAILED_WIRED:
             case Network.State.FAILED_WIFI:
             case Network.State.FAILED_VPN:
-                return 4;
+            case Network.State.FAILED_MOBILE:
+                return 6;
             case Network.State.DISCONNECTED_WIRED:
             case Network.State.DISCONNECTED_AIRPLANE_MODE:
-                return 5;
+                return 7;
             default:
-                return 6;
+                return 8;
         }
     }
 }
@@ -74,14 +90,21 @@ namespace Network.Common.Utils {
         case Network.State.CONNECTED_WIFI_EXCELLENT:
         case Network.State.CONNECTED_WIRED:
         case Network.State.CONNECTED_VPN:
+        case Network.State.CONNECTED_MOBILE:
+        case Network.State.CONNECTED_MOBILE_WEAK:
+        case Network.State.CONNECTED_MOBILE_OK:
+        case Network.State.CONNECTED_MOBILE_GOOD:
+        case Network.State.CONNECTED_MOBILE_EXCELLENT:
             return _("Connected");
         case Network.State.FAILED_WIRED:
         case Network.State.FAILED_WIFI:
         case Network.State.FAILED_VPN:
+        case Network.State.FAILED_MOBILE:
             return _("Failed");
         case Network.State.CONNECTING_WIFI:
         case Network.State.CONNECTING_WIRED:
         case Network.State.CONNECTING_VPN:
+        case Network.State.CONNECTING_MOBILE:
             return _("Connecting");
         case Network.State.WIRED_UNPLUGGED:
             return _("Cable unplugged");

--- a/src/common/Widgets/AbstractModemInterface.vala
+++ b/src/common/Widgets/AbstractModemInterface.vala
@@ -1,0 +1,38 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/*-
+ * Copyright (c) 2017 elementary LLC. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
+
+public abstract class Network.AbstractModemInterface : Network.WidgetNMInterface {
+
+	public override void update_name (int count) {
+		var name = device.get_description ();
+		if (count > 1) {
+			display_title = _("Mobile Broadband: %s").printf (name);
+		} else {
+			display_title = _("Mobile Broadband");
+		}
+
+		if (device is NM.DeviceModem) {
+			var capabilities = (device as NM.DeviceModem).get_current_capabilities ();
+			if (NM.DeviceModemCapabilities.POTS in capabilities) {
+				display_title = _("Modem");
+			}
+		}
+	}
+}

--- a/src/common/Widgets/AbstractModemInterface.vala
+++ b/src/common/Widgets/AbstractModemInterface.vala
@@ -19,20 +19,21 @@
  */
 
 public abstract class Network.AbstractModemInterface : Network.WidgetNMInterface {
+    protected NM.Client nm_client;
 
-	public override void update_name (int count) {
-		var name = device.get_description ();
-		if (count > 1) {
-			display_title = _("Mobile Broadband: %s").printf (name);
-		} else {
-			display_title = _("Mobile Broadband");
-		}
+    public override void update_name (int count) {
+        var name = device.get_description ();
+        if (count > 1) {
+            display_title = _("Mobile Broadband: %s").printf (name);
+        } else {
+            display_title = _("Mobile Broadband");
+        }
 
-		if (device is NM.DeviceModem) {
-			var capabilities = (device as NM.DeviceModem).get_current_capabilities ();
-			if (NM.DeviceModemCapabilities.POTS in capabilities) {
-				display_title = _("Modem");
-			}
-		}
-	}
+        if (device is NM.DeviceModem) {
+            var capabilities = (device as NM.DeviceModem).get_current_capabilities ();
+            if (NM.DeviceModemCapabilities.POTS in capabilities) {
+                display_title = _("Modem");
+            }
+        }
+    }
 }

--- a/src/common/Widgets/AbstractModemInterface.vala
+++ b/src/common/Widgets/AbstractModemInterface.vala
@@ -19,8 +19,6 @@
  */
 
 public abstract class Network.AbstractModemInterface : Network.WidgetNMInterface {
-    protected NM.Client nm_client;
-
     public override void update_name (int count) {
         var name = device.get_description ();
         if (count > 1) {

--- a/src/common/Widgets/NMVisualizer.vala
+++ b/src/common/Widgets/NMVisualizer.vala
@@ -109,6 +109,9 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
         } else if (device is NM.DeviceEthernet) {
             widget_interface = new EtherInterface (nm_client, nm_settings, device);
             debug ("Wired interface added");
+        } else if (device is NM.DeviceModem) {
+            widget_interface = new ModemInterface (nm_client, nm_settings, device);
+            debug ("Modem interface added");
         } else {
             debug ("Unknown device: %s\n", device.get_device_type().to_string());
         }


### PR DESCRIPTION
Fixes #2 (but doesn't close the bounty yet, as that refers to the switchboard plug too, which I'll do next!)

I don't know if anyone has the hardware to test this, but it functions as you'd expect with any cellular modem supported by NetworkManger and/or ModemManager. You can connect/disconnect using the toggle switch and it shows the signal strength in the icon. Can provide screenshots/screencasts if you don't believe me ;)

I've written the code in such a way that WiFi networks and wired networks take priority over the cellular network, so if you have either of those connected, they show their status icon in the panel rather than the cellular modem.