### PR TITLE
Improve cellular switch logic

### DIFF
--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -45,9 +45,9 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
 
         modem_item.get_style_context ().add_class ("h4");
         modem_item.switched.connect (() => {
-            if (modem_item.get_active ()) {
+            if (modem_item.get_active () && device.state == NM.DeviceState.DISCONNECTED) {
                 nm_client.activate_connection (null, device, null, null);
-            } else {
+            } else if (!modem_item.get_active () && device.state == NM.DeviceState.ACTIVATED) {
                 device.disconnect (() => { debug ("Successfully disconnected."); });
             }
         });


### PR DESCRIPTION
Only allow the toggle switch to change the state of the device when it's in a valid state. This doesn't affect the behavior of the indicator at all, it just fixes the indicator and the switchboard plug fighting each other. 