### PR TITLE
Display network type next to cellular indicator

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -47,6 +47,7 @@ public class Network.Indicator : Wingpanel.Indicator {
             popover_widget = new Widgets.PopoverWidget ();
             popover_widget.notify["state"].connect (on_state_changed);
             popover_widget.notify["secure"].connect (on_state_changed);
+            popover_widget.notify["extra-info"].connect (on_state_changed);
             popover_widget.settings_shown.connect (() => { close (); });
 
             on_state_changed ();
@@ -60,7 +61,7 @@ public class Network.Indicator : Wingpanel.Indicator {
         assert (popover_widget != null);
         assert (display_widget != null);
 
-        display_widget.update_state (popover_widget.state, popover_widget.secure);
+        display_widget.update_state (popover_widget.state, popover_widget.secure, popover_widget.extra_info);
     }
 
     private void start_monitor () {

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -36,7 +36,7 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
 
         extra_info_label = new Gtk.Label (null);
         extra_info_label.margin_left = 4;
-        extra_info_label.margin_bottom = 2;
+        extra_info_label.margin_bottom = 4;
         extra_info_label.valign = Gtk.Align.END;
         extra_info_label.vexpand = true;
         extra_info_label.no_show_all = true;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -18,6 +18,7 @@
 
 public class Network.Widgets.DisplayWidget : Gtk.Box {
     private Gtk.Image image;
+    private Gtk.Label extra_info_label;
 
     uint wifi_animation_timeout;
     int wifi_animation_state = 0;
@@ -33,10 +34,22 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
         image.icon_name = "network-wired-symbolic";
         image.icon_size = Gtk.IconSize.LARGE_TOOLBAR;
 
+        extra_info_label = new Gtk.Label (null);
+        extra_info_label.margin_left = 4;
+        extra_info_label.margin_bottom = 2;
+        extra_info_label.valign = Gtk.Align.END;
+        extra_info_label.vexpand = true;
+        extra_info_label.no_show_all = true;
+        extra_info_label.visible = false;
+
         pack_start (image);
+        pack_start (extra_info_label);
     }
 
-    public void update_state (Network.State state, bool secure) {
+    public void update_state (Network.State state, bool secure, string? extra_info = null) {
+        extra_info_label.visible = extra_info != null;
+        extra_info_label.label = extra_info;
+
         if (wifi_animation_timeout > 0) {
             Source.remove (wifi_animation_timeout);
             wifi_animation_timeout = 0;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -36,8 +36,7 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
 
         extra_info_label = new Gtk.Label (null);
         extra_info_label.margin_left = 4;
-        extra_info_label.margin_bottom = 4;
-        extra_info_label.valign = Gtk.Align.END;
+        extra_info_label.valign = Gtk.Align.CENTER;
         extra_info_label.vexpand = true;
         extra_info_label.no_show_all = true;
         extra_info_label.visible = false;

--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -19,6 +19,7 @@
 public class Network.Widgets.DisplayWidget : Gtk.Box {
     private Gtk.Image image;
     private Gtk.Label extra_info_label;
+    private Gtk.Revealer extra_info_revealer;
 
     uint wifi_animation_timeout;
     int wifi_animation_state = 0;
@@ -38,15 +39,17 @@ public class Network.Widgets.DisplayWidget : Gtk.Box {
         extra_info_label.margin_left = 4;
         extra_info_label.valign = Gtk.Align.CENTER;
         extra_info_label.vexpand = true;
-        extra_info_label.no_show_all = true;
-        extra_info_label.visible = false;
+
+        extra_info_revealer = new Gtk.Revealer ();
+        extra_info_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_LEFT;
+        extra_info_revealer.add (extra_info_label);
 
         pack_start (image);
-        pack_start (extra_info_label);
+        pack_start (extra_info_revealer);
     }
 
     public void update_state (Network.State state, bool secure, string? extra_info = null) {
-        extra_info_label.visible = extra_info != null;
+        extra_info_revealer.reveal_child = extra_info != null;
         extra_info_label.label = extra_info;
 
         if (wifi_animation_timeout > 0) {

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -35,7 +35,7 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
         }
     }
 
-    enum ModemAccessTechnology{
+    enum ModemAccessTechnology {
         UNKNOWN     = 0,
         POTS        = 1 << 0,
         GSM         = 1 << 1,

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -35,6 +35,26 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
         }
     }
 
+    enum ModemAccessTechnology{
+        UNKNOWN     = 0,
+        POTS        = 1 << 0,
+        GSM         = 1 << 1,
+        GSM_COMPACT = 1 << 2,
+        GPRS        = 1 << 3,
+        EDGE        = 1 << 4,
+        UMTS        = 1 << 5,
+        HSDPA       = 1 << 6,
+        HSUPA       = 1 << 7,
+        HSPA        = 1 << 8,
+        HSPA_PLUS   = 1 << 9,
+        1XRTT       = 1 << 10,
+        EVDO0       = 1 << 11,
+        EVDOA       = 1 << 12,
+        EVDOB       = 1 << 13,
+        LTE         = 1 << 14,
+        ANY         = 0xFFFFFFFF
+    }
+
     public ModemInterface (NM.Client nm_client, NM.RemoteSettings nm_settings, NM.Device? _device) {
         device = _device;
         modem_item = new Wingpanel.Widgets.Switch (display_title);
@@ -104,6 +124,37 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
         }
     }
 
+    private string? access_technology_to_string (ModemAccessTechnology tech) {
+        switch (tech) {
+            case ModemAccessTechnology.UNKNOWN:
+            case ModemAccessTechnology.POTS:
+            case ModemAccessTechnology.ANY:
+                return null;
+            case ModemAccessTechnology.GSM:
+            case ModemAccessTechnology.GSM_COMPACT:
+            case ModemAccessTechnology.GPRS:
+            case ModemAccessTechnology.1XRTT:
+                return "G";
+            case ModemAccessTechnology.EDGE:
+                return "E";
+            case ModemAccessTechnology.UMTS:
+            case ModemAccessTechnology.EVDO0:
+            case ModemAccessTechnology.EVDOA:
+            case ModemAccessTechnology.EVDOB:
+                return "3G";
+            case ModemAccessTechnology.HSDPA:
+            case ModemAccessTechnology.HSUPA:
+            case ModemAccessTechnology.HSPA:
+                return "H";
+            case ModemAccessTechnology.HSPA_PLUS:
+                return "H+";
+            case ModemAccessTechnology.LTE:
+                return "LTE";
+            default:
+                return null;
+        }
+    }
+
     private void device_properties_changed (Variant changed) {
         var signal_variant = changed.lookup_value ("SignalQuality", VariantType.TUPLE);
         if (signal_variant != null) {
@@ -111,6 +162,13 @@ public class Network.ModemInterface : Network.AbstractModemInterface {
             uint32 quality;
             signal_variant.get ("(ub)", out quality, out recent);
             signal_quality = quality;
+        }
+
+        var access_technologies_variant = changed.lookup_value ("AccessTechnologies", VariantType.UINT32);
+        if (access_technologies_variant != null) {
+            uint32 access_type;
+            access_technologies_variant.get ("u", out access_type);
+            extra_info = access_technology_to_string ((ModemAccessTechnology)access_type);
         }
     }
 

--- a/src/common/Widgets/NMVisualizer.vala
+++ b/src/common/Widgets/NMVisualizer.vala
@@ -23,6 +23,7 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
     protected GLib.List<WidgetNMInterface>? network_interface;
 
     public bool secure { private set; get; default = false; }
+    public string? extra_info { protected set; get; default = null; }
     public Network.State state { private set; get; default = Network.State.CONNECTING_WIRED; }
 
     construct {
@@ -123,6 +124,7 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
             network_interface.append (widget_interface);
             add_interface(widget_interface);
             widget_interface.notify["state"].connect(update_state);
+            widget_interface.notify["extra-info"].connect (update_state);
 
         }
 
@@ -168,6 +170,7 @@ public abstract class Network.Widgets.NMVisualizer : Gtk.Grid {
                 if (score < best_score) {
                     next_state = inter.state;
                     best_score = score;
+                    extra_info = inter.extra_info;
                 }
             }
 

--- a/src/common/Widgets/WidgetNMInterface.vala
+++ b/src/common/Widgets/WidgetNMInterface.vala
@@ -22,7 +22,7 @@ public abstract class Network.WidgetNMInterface : Gtk.Box {
 public abstract class Network.WidgetNMInterface : Network.Widgets.Page {
 #endif
 	public Network.State state { get; protected set; default = Network.State.DISCONNECTED; }
-
+    public string? extra_info { protected set; get; default = null; }
 	public string display_title { get; protected set; default = _("Unknown device"); }
 
 #if PLUG_NETWORK


### PR DESCRIPTION
Fixes #5 

Looks like the following:
![screenshot from 2017-09-25 00 22 52](https://user-images.githubusercontent.com/3372394/30787774-c48da07c-a188-11e7-8aa0-0727fc315098.png)

I believe the vertical alignment issue is caused by https://github.com/elementary/icons/issues/351

This has been tested with the large text setting and doesn't break things any more than any of the other large text in the panel.