### PR TITLE
Fix double separators

### DIFF
--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -25,7 +25,7 @@ public class Network.Widgets.PopoverWidget : Network.Widgets.NMVisualizer {
 
     public signal void settings_shown ();
 
-    bool is_dm () {
+    static bool is_dm () {
         return Environment.get_user_name () == Services.SettingsManager.get_default ().desktopmanager_user;
     }
 
@@ -67,10 +67,7 @@ public class Network.Widgets.PopoverWidget : Network.Widgets.NMVisualizer {
     }
 
     protected override void remove_interface (WidgetNMInterface widget_interface) {
-        if (widget_interface.sep != null) {
-            widget_interface.sep.destroy ();
-        }
-
+        widget_interface.sep.destroy ();
         widget_interface.destroy ();
     }
 
@@ -100,7 +97,6 @@ public class Network.Widgets.PopoverWidget : Network.Widgets.NMVisualizer {
         }
 
         if (!is_dm () && get_children ().length () > 0) {
-            widget_interface.sep = new Wingpanel.Widgets.Separator ();
             container_box.pack_end (widget_interface.sep);
         }
 

--- a/src/common/Widgets/WidgetNMInterface.vala
+++ b/src/common/Widgets/WidgetNMInterface.vala
@@ -34,7 +34,7 @@ public abstract class Network.WidgetNMInterface : Network.Widgets.Page {
 #endif
 
 #if INDICATOR_NETWORK
-	public Wingpanel.Widgets.Separator? sep = null;
+	public Wingpanel.Widgets.Separator sep { get; private set; default = new Wingpanel.Widgets.Separator (); }
 
 	public signal void show_dialog (Gtk.Widget w);
 	public signal void need_settings ();


### PR DESCRIPTION
Fixes #69.
Turns out that the separator was initialized lately in the process of creating an UI for a device which caused some interfaces like VpnInterface fail to update the visibility of a separator because it wasn't yet initialized. I made `is_dm` method static, because I thought it would be bitesize here.