### PR TITLE
Initialize everything on Indicator creation

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -28,31 +28,26 @@ public class Network.Indicator : Wingpanel.Indicator {
         Object (code_name: Wingpanel.Indicator.NETWORK,
                 display_name: _("Network"),
                 description: _("Network indicator"),
-                is_in_session: is_in_session);
+                is_in_session: is_in_session,
+                visible: true);
+
+        display_widget = new Widgets.DisplayWidget ();
+
+        popover_widget = new Widgets.PopoverWidget (is_in_session);
+        popover_widget.notify["state"].connect (on_state_changed);
+        popover_widget.notify["secure"].connect (on_state_changed);
+        popover_widget.notify["extra-info"].connect (on_state_changed);
+        popover_widget.settings_shown.connect (() => { close (); });
+
+        on_state_changed ();
+        start_monitor ();
     }
 
     public override Gtk.Widget get_display_widget () {
-        if (display_widget == null) {
-            display_widget = new Widgets.DisplayWidget ();
-        }
-
-        visible = true;
-
         return display_widget;
     }
 
     public override Gtk.Widget? get_widget () {
-        if (popover_widget == null) {
-            popover_widget = new Widgets.PopoverWidget (is_in_session);
-            popover_widget.notify["state"].connect (on_state_changed);
-            popover_widget.notify["secure"].connect (on_state_changed);
-            popover_widget.notify["extra-info"].connect (on_state_changed);
-            popover_widget.settings_shown.connect (() => { close (); });
-
-            on_state_changed ();
-            start_monitor ();
-        }
-
         return popover_widget;
     }
 


### PR DESCRIPTION
This branch is needed if https://github.com/elementary/wingpanel/pull/103 were to get merged, as everything that has to do with reading the network state depends on the popover widget being initialized...

Yes, i'm the first to admit that it's ugly having to initialize everything from the constructor, but sadly the whole logic with the network indicator is tightly dependent on the DisplayWidget :sad-dog: