### PR TITLE
Scan for APs on open indicator

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -78,11 +78,15 @@ public class Network.Indicator : Wingpanel.Indicator {
     }
 
     public override void opened () {
-        // TODO
+        if (popover_widget != null) {
+            popover_widget.opened ();
+        }
     }
 
     public override void closed () {
-        // TODO
+        if (popover_widget != null) {
+            popover_widget.closed ();
+        }
     }
 }
 

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -107,6 +107,22 @@ public class Network.Widgets.PopoverWidget : Network.Widgets.NMVisualizer {
         widget_interface.need_settings.connect (show_settings);
     }
 
+    public void opened () {
+        foreach (var widget in wifi_box.get_children ()) {
+            if (widget is WifiInterface) {
+                ((WifiInterface)widget).start_scanning ();
+            }
+        }
+    }
+
+    public void closed () {
+        foreach (var widget in wifi_box.get_children ()) {
+            if (widget is WifiInterface) {
+                ((WifiInterface)widget).cancel_scanning ();
+            }
+        }
+    }
+
     void show_settings () {
         if (is_in_session) {
             try {

--- a/src/Widgets/WifiInterface.vala
+++ b/src/Widgets/WifiInterface.vala
@@ -21,6 +21,8 @@ public class Network.WifiInterface : Network.AbstractWifiInterface {
     Wingpanel.Widgets.Switch wifi_item;
     Gtk.Revealer revealer;
 
+    Cancellable wifi_scan_cancellable = new Cancellable ();
+
     public WifiInterface (NM.Client nm_client, NM.Device? _device) {
         init_wifi_interface (nm_client, _device);
 
@@ -105,6 +107,15 @@ public class Network.WifiInterface : Network.AbstractWifiInterface {
          * signal is flushed (for instance signals responsible for radio button
          * checked) */
         Idle.add (() => { update (); return false; });
+    }
+
+    public void start_scanning () {
+        wifi_scan_cancellable.reset ();
+        wifi_device.request_scan_async.begin (wifi_scan_cancellable, null);
+    }
+
+    public void cancel_scanning () {
+        wifi_scan_cancellable.cancel ();
     }
 
     public void connect_to_hidden () {


### PR DESCRIPTION
Fixes #70 

I don't know if we should look at finding a good place to put a spinner in there, because it takes a second or two to go from showing just the one AP you're connected to, to showing the full list after opening the indicator. But I'll leave that as a UX discussion of how best to display that.

There's already a "scanning for APs" spinner that's shown as a placeholder when there's nothing in the listbox, but we always have the current AP in there in this case.