### PR TITLE
Truncate long network names - Ellipsize

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -75,3 +75,16 @@ public enum Network.State {
         }
     }
 }
+
+private const int MAX_WINDOW_NAME_LENGTH = 24;
+
+public string short_name_ellipsizee (string name) {
+    // Middle-ellipsize
+    string short_window_name = name;
+    if (name.length > MAX_WINDOW_NAME_LENGTH) {
+        string first_half = name.substring (0, (int)(MAX_WINDOW_NAME_LENGTH / 2));
+        string second_half = name.substring (- (int)(MAX_WINDOW_NAME_LENGTH / 2));
+        short_window_name = "%s…%s".printf (first_half, second_half);
+    }
+    return short_window_name;
+}

--- a/src/common/Widgets/AbstractEtherInterface.vala
+++ b/src/common/Widgets/AbstractEtherInterface.vala
@@ -30,6 +30,7 @@ public abstract class Network.AbstractEtherInterface : Network.WidgetNMInterface
                 display_title = name;
             }
         }
+        display_title = short_name_ellipsizee (display_title);
     }
 
     public override void update () {

--- a/src/common/Widgets/AbstractModemInterface.vala
+++ b/src/common/Widgets/AbstractModemInterface.vala
@@ -26,6 +26,7 @@ public abstract class Network.AbstractModemInterface : Network.WidgetNMInterface
         } else {
             display_title = _("Mobile Broadband");
         }
+        display_title = short_name_ellipsizee (display_title);
 
         if (device is NM.DeviceModem) {
             var capabilities = (device as NM.DeviceModem).get_current_capabilities ();

--- a/src/common/Widgets/VpnMenuItem.vala
+++ b/src/common/Widgets/VpnMenuItem.vala
@@ -79,7 +79,7 @@ public class Network.VpnMenuItem : Gtk.ListBoxRow {
     }
 
     private void update () {
-        radio_button.label = connection.get_id ();
+        radio_button.label = short_name_ellipsizee (connection.get_id ());
         hide_item (error_img);
         hide_item (spinner);
 

--- a/src/common/Widgets/WifiMenuItem.vala
+++ b/src/common/Widgets/WifiMenuItem.vala
@@ -17,6 +17,7 @@
 
 public class Network.WifiMenuItem : Gtk.ListBoxRow {
     private List<NM.AccessPoint> _ap;
+
     public signal void user_action ();
     public GLib.Bytes ssid {
         get {
@@ -119,7 +120,8 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
     }
 
     private void update () {
-        radio_button.label = NM.Utils.ssid_to_utf8 (ap.get_ssid ().get_data ());
+        string ssid_name = NM.Utils.ssid_to_utf8 (ap.get_ssid ().get_data ());
+        radio_button.label = short_name_ellipsizee (ssid_name);
 
         img_strength.icon_name = get_strength_symbolic_icon ();
         img_strength.show_all ();


### PR DESCRIPTION
closes #152 

Truncate network name (wired/ modem/ ssid/ vpn) to 24 chars (I tested some), using the method described under https://github.com/elementary/dock/pull/19

![Untitled](https://user-images.githubusercontent.com/1039615/87101327-34954e00-c225-11ea-87e3-739564409d34.png)

I didn't know exactly how to proceed on the modem case, where most of the string (18/24 chars) is a standard message:

```
  display_title = _("Mobile Broadband: %s").printf (name);
```

I ended up using the same technique, but maybe keep the default string and cut the rest (`name`)?
