### PR TITLE
AbstractWifiInterface: misc cleanup

### DIFF
--- a/src/common/Widgets/AbstractWifiInterface.vala
+++ b/src/common/Widgets/AbstractWifiInterface.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2015-2018 elementary LLC (https://elementary.io)
+* Copyright 2015-2020 elementary, Inc. (https://elementary.io)
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Library General Public License as published by


### PR DESCRIPTION
* Bump copyright header
* Move UI construction to `construct`
* Code style
* Remove extra boxes
* Make placeholderlabel a private class
* Use a single `show_all` instead of lots of `visible`
* Remove unnecessary empty box when placeholder is automatically hidden