### PR TITLE
Release 2.2.5

### DIFF
--- a/data/network.appdata.xml.in
+++ b/data/network.appdata.xml.in
@@ -6,6 +6,16 @@
   <name>Network Indicator</name>
   <summary>Connect to wireless networks and manage VPNs</summary>
   <releases>
+    <release version="2.2.5" date="2020-10-08" urgency="medium">
+      <description>
+        <p>Minor updates</p>
+        <ul>
+          <li>Improve detection and labeling of encryption types</li>
+          <li>Improve reliability of connection dialog</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.2.4" date="2020-05-28" urgency="medium">
       <description>
         <p>Updated translations</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'network',
     'vala', 'c',
-    version: '2.2.4'
+    version: '2.2.5'
 )
 
 gettext_name = meson.project_name() + '-indicator'


### PR DESCRIPTION
It's been a while, we're still compatible with 5.x, and there's been lots of cleanup and a few little improvements.

https://github.com/elementary/wingpanel-indicator-network/compare/2.2.4...release-2.2.5