### PR TITLE
Move extra_info to ModemInterface

### DIFF
--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -18,6 +18,8 @@
  */
 
 public class Network.ModemInterface : Network.WidgetNMInterface {
+    public string? extra_info { get; private set; default = null; }
+
     private Wingpanel.Widgets.Switch modem_item;
     private DBusObjectManagerClient? modem_manager;
 

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -250,7 +250,9 @@ public class Network.Widgets.PopoverWidget : Gtk.Grid {
                 if (score < best_score) {
                     next_state = inter.state;
                     best_score = score;
-                    extra_info = inter.extra_info;
+                    if (inter is Network.ModemInterface) {
+                        extra_info = ((Network.ModemInterface) inter).extra_info;
+                    }
                 }
             }
 

--- a/src/common/Widgets/WidgetNMInterface.vala
+++ b/src/common/Widgets/WidgetNMInterface.vala
@@ -18,7 +18,6 @@
 public abstract class Network.WidgetNMInterface : Gtk.Box {
     protected NM.Device? device;
     public Network.State state { get; protected set; default = Network.State.DISCONNECTED; }
-    public string? extra_info { protected set; get; default = null; }
     public string display_title { get; protected set; default = _("Unknown device"); }
 
     public Wingpanel.Widgets.Separator sep { get; private set; default = new Wingpanel.Widgets.Separator (); }


### PR DESCRIPTION
This property is only ever set in ModemInterface so it doesn't need to be a part of Network.WidgetNMInterface