### PR TITLE
Fix tooltip showing stale disconnected label on first boot

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -58,6 +58,8 @@ public class Network.Indicator : Wingpanel.Indicator {
         assert (display_widget != null);
 
         display_widget.update_state (popover_widget.state, popover_widget.secure, popover_widget.extra_info);
+
+        update_tooltip ();
     }
 
     private void start_monitor () {


### PR DESCRIPTION
This PR is to fix the indicator tooltip which shows "Disconnected" when I first boot up and the greeter starts even though my wifi is connected.