### PR TITLE
Use disambiguate_names from NM

### DIFF
--- a/src/Widgets/EtherInterface.vala
+++ b/src/Widgets/EtherInterface.vala
@@ -49,21 +49,6 @@ public class Network.EtherInterface : Network.WidgetNMInterface {
         device.state_changed.connect (() => { update (); });
     }
 
-    public override void update_name (int count) {
-        var name = device.get_description ();
-
-        /* At least for docker related interfaces, which can be fairly common */
-        if (name.has_prefix ("veth")) {
-            display_title = _("Virtual network: %s").printf (name);
-        } else {
-            if (count <= 1) {
-                display_title = _("Wired");
-            } else {
-                display_title = name;
-            }
-        }
-    }
-
     public override void update () {
         switch (device.get_state ()) {
         case NM.DeviceState.UNKNOWN:

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -79,22 +79,6 @@ public class Network.ModemInterface : Network.WidgetNMInterface {
         prepare.begin ();
     }
 
-    public override void update_name (int count) {
-        var name = device.get_description ();
-        if (count > 1) {
-            display_title = _("Mobile Broadband: %s").printf (name);
-        } else {
-            display_title = _("Mobile Broadband");
-        }
-
-        if (device is NM.DeviceModem) {
-            var capabilities = ((NM.DeviceModem)device).get_current_capabilities ();
-            if (NM.DeviceModemCapabilities.POTS in capabilities) {
-                display_title = _("Modem");
-            }
-        }
-    }
-
     public override void update () {
         switch (device.state) {
             case NM.DeviceState.UNKNOWN:

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -207,19 +207,15 @@ public class Network.Widgets.PopoverWidget : Gtk.Grid {
     }
 
     private void update_interfaces_names () {
-        var count_type = new Gee.HashMap<string, int?> ();
-        foreach (var iface in network_interface) {
-            var type = iface.get_type ().name ();
-            if (count_type.has_key (type)) {
-                count_type[type] = count_type[type] + 1;
-            } else {
-                count_type[type] = 1;
-            }
+        NM.Device[] devices = {};
+        foreach (unowned var iface in network_interface) {
+            devices += iface.device;
         }
 
-        foreach (var iface in network_interface) {
-            var type = iface.get_type ().name ();
-            iface.update_name (count_type [type]);
+        var names = NM.Device.disambiguate_names (devices);
+
+        for (int i = 0; i < network_interface.length (); i++) {
+            network_interface.nth_data (i).display_title = names[i];
         }
     }
 

--- a/src/Widgets/VpnInterface.vala
+++ b/src/Widgets/VpnInterface.vala
@@ -86,10 +86,6 @@ public class Network.VpnInterface : Network.WidgetNMInterface {
         nm_client.get_connections ().foreach ((connection) => vpn_added_cb (connection));
     }
 
-    public override void update_name (int count) {
-        display_title = _("VPN");
-    }
-
     public override void update () {
         update_active_connection ();
 

--- a/src/Widgets/WifiInterface.vala
+++ b/src/Widgets/WifiInterface.vala
@@ -132,14 +132,6 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
         pack_start (revealer);
     }
 
-    public override void update_name (int count) {
-        if (count <= 1) {
-            display_title = _("Wireless");
-        } else {
-            display_title = device.get_description ();
-        }
-    }
-
     public override void update () {
         switch (wifi_device.state) {
         case NM.DeviceState.UNKNOWN:

--- a/src/common/Widgets/WidgetNMInterface.vala
+++ b/src/common/Widgets/WidgetNMInterface.vala
@@ -16,9 +16,9 @@
  */
 
 public abstract class Network.WidgetNMInterface : Gtk.Box {
-    protected NM.Device? device;
+    public NM.Device? device { get; protected set; }
     public Network.State state { get; protected set; default = Network.State.DISCONNECTED; }
-    public string display_title { get; protected set; default = _("Unknown device"); }
+    public string display_title { get; set; default = _("Unknown device"); }
 
     public Gtk.Separator sep { get; construct; }
 
@@ -34,9 +34,5 @@ public abstract class Network.WidgetNMInterface : Gtk.Box {
     }
 
     public virtual void update () {
-    }
-
-    public virtual void update_name (int count) {
-        display_title = _("Unknown type: %s ").printf (device.get_description ());
     }
 }


### PR DESCRIPTION
Network Manager has a built-in function for disambiguating device names, so let's use that instead of reinventing the wheel