### PR TITLE
WifiInterface: use NM.DeviceState

### DIFF
--- a/src/Widgets/WifiInterface.vala
+++ b/src/Widgets/WifiInterface.vala
@@ -139,7 +139,7 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
         case NM.DeviceState.FAILED:
             state = State.FAILED_WIFI;
             if (active_wifi_item != null) {
-                active_wifi_item.state = state;
+                active_wifi_item.state = wifi_device.state;
             }
             cancel_scan ();
             break;
@@ -445,8 +445,8 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
         active_ap = wifi_device.get_active_access_point ();
 
         if (active_wifi_item != null) {
-            if (active_wifi_item.state == Network.State.CONNECTING_WIFI) {
-                active_wifi_item.state = Network.State.DISCONNECTED;
+            if (active_wifi_item.state == NM.DeviceState.CONFIG) {
+                active_wifi_item.state = NM.DeviceState.DISCONNECTED;
             }
             active_wifi_item = null;
         }
@@ -467,7 +467,7 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
                     found = true;
                     menu_item.set_active (true);
                     active_wifi_item = menu_item;
-                    active_wifi_item.state = state;
+                    active_wifi_item.state = device.state;
                 }
             }
 

--- a/src/common/Widgets/WifiMenuItem.vala
+++ b/src/common/Widgets/WifiMenuItem.vala
@@ -24,7 +24,7 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
         }
     }
 
-    public Network.State state { get; set; default=Network.State.DISCONNECTED; }
+    public NM.DeviceState state { get; set; default = NM.DeviceState.DISCONNECTED; }
 
     public uint8 strength {
         get {
@@ -163,15 +163,20 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
         hide_item (spinner);
 
         switch (state) {
-        case State.FAILED_WIFI:
-            show_item (error_img);
-            break;
-        case State.CONNECTING_WIFI:
-            show_item (spinner);
-            if (!radio_button.active) {
-                critical ("An access point is being connected but not active.");
-            }
-            break;
+            case NM.DeviceState.FAILED:
+                show_item (error_img);
+                break;
+            case NM.DeviceState.PREPARE:
+            case NM.DeviceState.CONFIG:
+            case NM.DeviceState.NEED_AUTH:
+            case NM.DeviceState.IP_CONFIG:
+            case NM.DeviceState.IP_CHECK:
+            case NM.DeviceState.SECONDARIES:
+                show_item (spinner);
+                if (!radio_button.active) {
+                    critical ("An access point is being connected but not active.");
+                }
+                break;
         }
     }
 


### PR DESCRIPTION
Towards eventually removing `Network.State` like we did in Switchboard since NM provides state enums already