### PR TITLE
Revert "WifiMenuItem: use built-in activate signal"

### DIFF
--- a/src/Widgets/WifiInterface.vala
+++ b/src/Widgets/WifiInterface.vala
@@ -140,12 +140,6 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
         orientation = Gtk.Orientation.VERTICAL;
         pack_start (wifi_item);
         pack_start (revealer);
-
-        wifi_list.row_activated.connect ((row) => {
-            if (row is WifiMenuItem) {
-                wifi_activate_cb ((WifiMenuItem) row);
-            }
-        });
     }
 
     public override void update () {
@@ -445,6 +439,7 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
 
             previous_wifi_item = item;
             item.set_visible (true);
+            item.user_action.connect (wifi_activate_cb);
 
             wifi_list.add (item);
             wifi_list.show_all ();

--- a/src/Widgets/WifiMenuItem.vala
+++ b/src/Widgets/WifiMenuItem.vala
@@ -17,6 +17,7 @@
 
 public class Network.WifiMenuItem : Gtk.ListBoxRow {
     private List<NM.AccessPoint> _ap;
+    public signal void user_action ();
     public GLib.Bytes ssid {
         get {
             return _tmp_ap.get_ssid ();
@@ -91,8 +92,10 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
 
         notify["state"].connect (update);
         radio_button.notify["active"].connect (update);
-        radio_button.toggled.connect (() => {
-            activate ();
+
+        radio_button.button_release_event.connect ((b, ev) => {
+            user_action ();
+            return false;
         });
 
         add (grid);


### PR DESCRIPTION
Reverts elementary/wingpanel-indicator-network#275

This seems to have introduced some weird behavior where the menuitem is reactivated in a loop forever