### PR TITLE
Add styles to screen

### DIFF
--- a/data/Indicator.css
+++ b/data/Indicator.css
@@ -3,19 +3,26 @@
 * SPDX-FileCopyrightText: 2023 elementary, Inc. (https://elementary.io)
 */
 
-.image-button.circular {
-    background: alpha(@text_color, 0.1);
+network .image-button.toggle {
+    border-radius: 1em;
+}
+
+network .image-button {
     border: none;
     box-shadow: none;
     min-height: 2.1666rem; /* 26px */
     min-width: 2.1666rem; /* 26px */
 }
 
-.image-button:checked.circular {
+network .image-button {
+    background: alpha(@text_color, 0.1);
+}
+
+network .image-button:checked {
     background: @selected_bg_color;
     color: @selected_fg_color;
 }
 
-.image-button:disabled.circular {
+network .image-button:disabled {
     background: @insensitive_bg_color;
 }

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -37,6 +37,15 @@ public class Network.Indicator : Wingpanel.Indicator {
 
         display_widget = new Widgets.DisplayWidget ();
 
+        var provider = new Gtk.CssProvider ();
+        provider.load_from_resource ("io/elementary/wingpanel/network/Indicator.css");
+
+        Gtk.StyleContext.add_provider_for_screen (
+            Gdk.Screen.get_default (),
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
+
         popover_widget = new Widgets.PopoverWidget (is_in_session);
         popover_widget.notify["state"].connect (on_state_changed);
         popover_widget.notify["secure"].connect (on_state_changed);

--- a/src/Widgets/EtherInterface.vala
+++ b/src/Widgets/EtherInterface.vala
@@ -18,12 +18,6 @@
 
 public class Network.EtherInterface : Network.WidgetNMInterface {
     private Gtk.ToggleButton ethernet_item;
-    private static Gtk.CssProvider provider;
-
-    static construct {
-        provider = new Gtk.CssProvider ();
-        provider.load_from_resource ("io/elementary/wingpanel/network/Indicator.css");
-    }
 
     public EtherInterface (NM.Client nm_client, NM.Device? _device) {
         device = _device;
@@ -32,8 +26,6 @@ public class Network.EtherInterface : Network.WidgetNMInterface {
             halign = Gtk.Align.CENTER,
             image = new Gtk.Image.from_icon_name ("panel-network-wired-connected-symbolic", Gtk.IconSize.MENU)
         };
-        ethernet_item.get_style_context ().add_class ("circular");
-        ethernet_item.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var label = new Gtk.Label (display_title) {
             ellipsize = Pango.EllipsizeMode.MIDDLE,

--- a/src/Widgets/ModemInterface.vala
+++ b/src/Widgets/ModemInterface.vala
@@ -55,12 +55,6 @@ public class Network.ModemInterface : Network.WidgetNMInterface {
 
     private DBusObjectManagerClient? modem_manager;
     private Gtk.ToggleButton modem_item;
-    private static Gtk.CssProvider provider;
-
-    static construct {
-        provider = new Gtk.CssProvider ();
-        provider.load_from_resource ("io/elementary/wingpanel/network/Indicator.css");
-    }
 
     public ModemInterface (NM.Client nm_client, NM.Device? _device) {
         device = _device;
@@ -69,8 +63,6 @@ public class Network.ModemInterface : Network.WidgetNMInterface {
             halign = Gtk.Align.CENTER,
             image = new Gtk.Image.from_icon_name ("panel-network-cellular-connected-symbolic", Gtk.IconSize.MENU)
         };
-        modem_item.get_style_context ().add_class ("circular");
-        modem_item.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         var label = new Gtk.Label (display_title) {
             ellipsize = Pango.EllipsizeMode.MIDDLE,

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -39,6 +39,10 @@ public class Network.Widgets.PopoverWidget : Gtk.Grid {
         Object (is_in_session: is_in_session);
     }
 
+    class construct {
+        set_css_name ("network");
+    }
+
     construct {
         network_interface = new GLib.List<WidgetNMInterface> ();
 
@@ -65,15 +69,10 @@ public class Network.Widgets.PopoverWidget : Gtk.Grid {
         }
 
         if (is_in_session) {
-            var provider = new Gtk.CssProvider ();
-            provider.load_from_resource ("io/elementary/wingpanel/network/Indicator.css");
-
             var airplane_toggle = new Gtk.ToggleButton () {
                 halign = Gtk.Align.CENTER,
                 image = new Gtk.Image.from_icon_name ("airplane-mode-symbolic", Gtk.IconSize.MENU)
             };
-            airplane_toggle.get_style_context ().add_class ("circular");
-            airplane_toggle.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
             var airplane_label = new Gtk.Label (_("Airplane Mode"));
             airplane_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);

--- a/src/Widgets/VpnMenuItem.vala
+++ b/src/Widgets/VpnMenuItem.vala
@@ -41,16 +41,10 @@ public class Network.VpnMenuItem : Gtk.FlowBoxChild {
         }
     }
 
-    private static Gtk.CssProvider provider;
     private Gtk.ToggleButton toggle_button;
 
     public VpnMenuItem (NM.RemoteConnection remote_connection) {
         Object (remote_connection: remote_connection);
-    }
-
-    static construct {
-        provider = new Gtk.CssProvider ();
-        provider.load_from_resource ("io/elementary/wingpanel/network/Indicator.css");
     }
 
     construct {
@@ -58,9 +52,6 @@ public class Network.VpnMenuItem : Gtk.FlowBoxChild {
             halign = Gtk.Align.CENTER,
             image = new Gtk.Image.from_icon_name ("panel-network-vpn-disconnected-symbolic", Gtk.IconSize.MENU)
         };
-        toggle_button.get_style_context ().add_class ("circular");
-        toggle_button.get_style_context ().add_provider (provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-
 
         var label = new Gtk.Label (remote_connection.get_id ()) {
             ellipsize = Pango.EllipsizeMode.MIDDLE,


### PR DESCRIPTION
Adding a provider to a style context is deprecated. Uses the same styles from Quick Settings. Toggles are now round-rects
![Screenshot from 2025-04-21 18 34 16](https://github.com/user-attachments/assets/4755a63d-ca27-4cdd-89e4-4ad5c1adcfc1)
