### PR TITLE
meson: Require gio-2.0 >= 2.74

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 You'll need the following dependencies:
 
 * gobject-introspection
+* libglib2.0-dev (>= 2.74)
 * libgranite-dev
-* libnm-dev
+* libnm-dev (>= 1.24)
 * libnma-dev
 * libpolkit-gobject-1-dev
 * libwingpanel-dev

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ shared_module(
     'src/Widgets/WifiMenuItem.vala',
     gresource,
     dependencies: [
+        dependency('gio-2.0', version: '>=2.74'),
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
         dependency('granite'),


### PR DESCRIPTION
We now use `GLib.ListStore.n_items` since #326:

```diff
     private void check_vpn_availability () {
-        show_vpn (vpn_list.get_child_at_index (0) != null);
+        show_vpn (vpn_list.n_items > 0);
     }
```

This is available on gio-2.0 >= 2.74 as written in [Valadoc](https://valadoc.org/gio-2.0/GLib.ListStore.n_items.html), so make sure to require it. Also explicit that we require libnm-dev >= 1.24 in README

---

I noticed this because the daily recipe of wingpanel-indicator-network fails in Jammy:

https://code.launchpad.net/~elementary-os/+archive/ubuntu/daily/+build/30646060

```
../src/Widgets/VpnInterface.vala:57.19-57.34: error: `GLib.ListStore.n_items' is not available in gio-2.0 2.72.4. Use gio-2.0 >= 2.74
   57 |         show_vpn (vpn_list.n_items > 0);
      |                   ^~~~~~~~~~~~~~~~      
Compilation failed: 1 error(s), 0 warning(s)
ninja: build stopped: subcommand failed.
```

Our development target is now Noble, so I dropped Jammy from the above recipe.
