### PR TITLE
Metainfo: add 8.0.0 release notes

### DIFF
--- a/data/network.metainfo.xml.in
+++ b/data/network.metainfo.xml.in
@@ -31,6 +31,16 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.0.0" date="2025-05-01" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>Jump to settings by middle-clicking on toggles</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="7.1.1" date="2024-07-17" urgency="medium">
       <description>
         <p>Improvements:</p>


### PR DESCRIPTION
Bump to 8 because we stopped building for Jammy