### PR TITLE
AirplaneMode: use RFKill

### DIFF
--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -69,13 +69,13 @@ public class Network.Indicator : Wingpanel.Indicator {
         rfkill = new RFKillManager ();
         rfkill.open ();
 
-        airplane_action = new SimpleAction.stateful ("airplane-mode", null, new Variant.boolean (rfkill.get_airplane_mode ()));
+        airplane_action = new SimpleAction.stateful ("airplane-mode", null, new Variant.boolean (rfkill.airplane_mode));
         airplane_action.activate.connect (() => {
-            rfkill.set_software_lock (ALL, !rfkill.get_airplane_mode ());
+            rfkill.airplane_mode = !rfkill.airplane_mode;
         });
 
         rfkill.device_changed.connect (() => {
-            airplane_action.set_state (new Variant.boolean (rfkill.get_airplane_mode ()));
+            airplane_action.set_state (new Variant.boolean (rfkill.airplane_mode));
         });
 
         var action_group = (SimpleActionGroup) popover_widget.get_action_group ("network");

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -22,6 +22,7 @@ public class Network.Indicator : Wingpanel.Indicator {
 
     NetworkMonitor network_monitor;
 
+    private RFKillManager rfkill;
     private Gtk.GestureMultiPress gesture_click;
     private SimpleAction airplane_action;
 
@@ -65,19 +66,16 @@ public class Network.Indicator : Wingpanel.Indicator {
             });
         }
 
-        airplane_action = new SimpleAction.stateful ("airplane-mode", null, new Variant.boolean (popover_widget.nm_client.networking_get_enabled ()));
+        rfkill = new RFKillManager ();
+        rfkill.open ();
+
+        airplane_action = new SimpleAction.stateful ("airplane-mode", null, new Variant.boolean (rfkill.get_airplane_mode ()));
         airplane_action.activate.connect (() => {
-            popover_widget.nm_client.dbus_call.begin (
-                NM.DBUS_PATH, NM.DBUS_INTERFACE,
-                "Enable", new Variant.tuple ({new Variant.boolean (!popover_widget.nm_client.networking_get_enabled ())}),
-                null, -1, null, (obj, res) => {
-                    try {
-                        ((NM.Client) obj).dbus_set_property.end (res);
-                    } catch (Error e) {
-                        warning ("Error setting airplane mode: %s", e.message);
-                    }
-                }
-            );
+            rfkill.set_software_lock (ALL, !rfkill.get_airplane_mode ());
+        });
+
+        rfkill.device_changed.connect (() => {
+            airplane_action.set_state (new Variant.boolean (rfkill.get_airplane_mode ()));
         });
 
         var action_group = (SimpleActionGroup) popover_widget.get_action_group ("network");
@@ -101,8 +99,6 @@ public class Network.Indicator : Wingpanel.Indicator {
         assert (display_widget != null);
 
         display_widget.update_state (popover_widget.state, popover_widget.secure, popover_widget.extra_info);
-
-        airplane_action.set_state (new Variant.boolean (!popover_widget.nm_client.networking_get_enabled ()));
 
         update_tooltip ();
     }

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -65,7 +65,6 @@ public class Network.Widgets.PopoverWidget : Gtk.Box {
 
             var action_group = new SimpleActionGroup ();
             action_group.action_state_changed.connect ((action_name, state) => {
-                critical ("got a state change");
                 if (action_name == "airplane-mode") {
                     if (state.get_boolean ()) {
                         airplane_toggle.icon_name = "airplane-mode-symbolic";

--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -80,6 +80,29 @@ public class RFKillManager : Object {
         return devices;
     }
 
+    /*
+    * Checks for Airplane mode
+    * Setting airplane mode from here does all software lock, whereas setting
+    * from a key press does all hardware lock. We need one of these two things—
+    * all devices to be locked somehow—to consider it Airplane Mode
+    */
+    public bool get_airplane_mode () {
+        var all_hardware_locked = true;
+        var all_software_locked = true;
+
+        foreach (unowned var device in get_devices ()) {
+            if (!device.software_lock) {
+                all_software_locked = false;
+            }
+
+            if (!device.hardware_lock) {
+                all_hardware_locked = false;
+            }
+        }
+
+        return all_hardware_locked || all_software_locked;
+    }
+
     public void set_software_lock (RFKillDeviceType type, bool lock_enabled) {
         var event = RFKillEvent ();
         event.type = type;

--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -116,6 +116,11 @@ public class RFKillManager : Object {
             set_software_lock (UWB, value);
             set_software_lock (WIMAX, value);
             set_software_lock (WMAN, value);
+
+            // Some hardware keys still turn off bluetooth
+            if (value) {
+                set_software_lock (BLUETOOTH, value);
+            }
         }
     }
 

--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -81,26 +81,42 @@ public class RFKillManager : Object {
     }
 
     /*
-    * Checks for Airplane mode
+    * Toggle Airplane Mode
+    *
+    * Modern mobile platforms don't disable Bluetooth, we skip it too
+    *
     * Setting airplane mode from here does all software lock, whereas setting
     * from a key press does all hardware lock. We need one of these two things—
     * all devices to be locked somehow—to consider it Airplane Mode
     */
-    public bool get_airplane_mode () {
-        var all_hardware_locked = true;
-        var all_software_locked = true;
+    public bool airplane_mode {
+        get {
+            var all_hardware_locked = true;
+            var all_software_locked = true;
 
-        foreach (unowned var device in get_devices ()) {
-            if (!device.software_lock) {
-                all_software_locked = false;
+            foreach (unowned var device in get_devices ()) {
+                if (device.device_type == BLUETOOTH) {
+                    continue;
+                }
+
+                if (!device.software_lock) {
+                    all_software_locked = false;
+                }
+
+                if (!device.hardware_lock) {
+                    all_hardware_locked = false;
+                }
             }
 
-            if (!device.hardware_lock) {
-                all_hardware_locked = false;
-            }
+            return all_hardware_locked || all_software_locked;
         }
 
-        return all_hardware_locked || all_software_locked;
+        set {
+            set_software_lock (WLAN, value);
+            set_software_lock (UWB, value);
+            set_software_lock (WIMAX, value);
+            set_software_lock (WMAN, value);
+        }
     }
 
     public void set_software_lock (RFKillDeviceType type, bool lock_enabled) {

--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -118,8 +118,8 @@ public class RFKillManager : Object {
             set_software_lock (WMAN, value);
 
             // Some hardware keys still turn off bluetooth
-            if (value) {
-                set_software_lock (BLUETOOTH, value);
+            if (!value) {
+                set_software_lock (BLUETOOTH, false);
             }
         }
     }


### PR DESCRIPTION
This changes Airplane Mode so that it uses RFKill to disable _radios_, not disable all _networking_. This means Airplane mode correctly disables wifi and cellular, but not wired networking

Partially fixes #45. The toggle is now correct but the indicator is not