### PR TITLE
rfkill: Use sizeof instead of literal size

### DIFF
--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -28,7 +28,7 @@ public class RFKillDevice {
             event.idx = idx;
             event.op = RFKillOperation.CHANGE;
             event.soft = value ? 1 : 0;
-            if (Posix.write (manager.fd, &event, 8) != 8)
+            if (Posix.write (manager.fd, &event, sizeof (event)) != sizeof (event))
                 return;
         }
     }
@@ -139,7 +139,7 @@ public class RFKillManager : Object {
         event.type = type;
         event.op = RFKillOperation.CHANGE_ALL;
         event.soft = lock_enabled ? 1 : 0;
-        if (Posix.write (fd, &event, 8) != 8)
+        if (Posix.write (fd, &event, sizeof (event)) != sizeof (event))
             return;
     }
 
@@ -148,7 +148,7 @@ public class RFKillManager : Object {
 
     private bool read_event () {
         var event = RFKillEvent ();
-        if (Posix.read (fd, &event, 8) != 8)
+        if (Posix.read (fd, &event, sizeof (event)) != sizeof (event))
             return false;
 
         switch (event.op) {

--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -28,7 +28,7 @@ public class RFKillDevice {
             event.idx = idx;
             event.op = RFKillOperation.CHANGE;
             event.soft = value ? 1 : 0;
-            if (Posix.write (manager.fd, &event, sizeof (event)) != sizeof (event))
+            if (Posix.write (manager.fd, &event, sizeof (RFKillEvent)) != sizeof (RFKillEvent))
                 return;
         }
     }
@@ -139,7 +139,7 @@ public class RFKillManager : Object {
         event.type = type;
         event.op = RFKillOperation.CHANGE_ALL;
         event.soft = lock_enabled ? 1 : 0;
-        if (Posix.write (fd, &event, sizeof (event)) != sizeof (event))
+        if (Posix.write (fd, &event, sizeof (RFKillEvent)) != sizeof (RFKillEvent))
             return;
     }
 
@@ -148,7 +148,7 @@ public class RFKillManager : Object {
 
     private bool read_event () {
         var event = RFKillEvent ();
-        if (Posix.read (fd, &event, sizeof (event)) != sizeof (event))
+        if (Posix.read (fd, &event, sizeof (RFKillEvent)) != sizeof (RFKillEvent))
             return false;
 
         switch (event.op) {


### PR DESCRIPTION
Unfortunately we can't seem to give variable names to `sizeof()` in Vala, but this should be better than literal from the view of readability of the code and possibility of size change of RFKillEvent in the future at least.
