### PR TITLE
PopoverWidget: Compare with result of get_first_child, not its address

### DIFF
--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -183,7 +183,7 @@ public class Network.Widgets.PopoverWidget : Gtk.Box {
 
         container_box.append (widget_interface);
 
-        if (is_in_session && get_first_child != null) {
+        if (is_in_session && get_first_child () != null) {
             container_box.append (widget_interface.sep);
         }
     }


### PR DESCRIPTION
Fixes the following build warning:

```
../src/Widgets/PopoverWidget.vala: In function ‘network_widgets_popover_widget_add_interface’:
../src/Widgets/PopoverWidget.vala:186:40: warning: the comparison will always evaluate as ‘true’ for the address of ‘gtk_widget_get_first_child’ will never be NULL [-Waddress]
  186 |         if (is_in_session && get_first_child != null) {
      |                                        ^~
In file included from /usr/include/gtk-4.0/gtk/gtkapplication.h:26,
                 from /usr/include/gtk-4.0/gtk/gtkwindow.h:32,
                 from /usr/include/gtk-4.0/gtk/gtkaboutdialog.h:29,
                 from /usr/include/gtk-4.0/gtk/gtk.h:33,
                 from /usr/include/wingpanel-9/wingpanel-9.h:7,
                 from ./network.h:9,
                 from libnetwork.so.p/src/Widgets/PopoverWidget.c:9:
/usr/include/gtk-4.0/gtk/gtkwidget.h:888:25: note: ‘gtk_widget_get_first_child’ declared here
  888 | GtkWidget *             gtk_widget_get_first_child      (GtkWidget *widget);
      |
```
