### PR TITLE
Fix wifi toggle not working from panel indicator after being turned off

### DIFF
--- a/src/Widgets/WifiInterface.vala
+++ b/src/Widgets/WifiInterface.vala
@@ -148,7 +148,12 @@ public class Network.WifiInterface : Network.WidgetNMInterface {
             }
         });
     }
-
+        if (state) {
+            nm_client.networking_enabled = true;
+            nm_client.wireless_enabled = true;
+        } else {
+            nm_client.wireless_enabled = false;
+        }
     private void update () {
         switch (wifi_device.state) {
         case NM.DeviceState.UNKNOWN:


### PR DESCRIPTION
## Summary  Fixes #16 / LP#1593937  When a user turns wifi off via the panel indicator and then tries to turn it back on using the same indicator toggle, nothing happens. The user has to open Network Settings to re-enable wifi.  ## Root Cause  `on_wifi_switch_state_set()` was only setting `nm_client